### PR TITLE
📦 Bump versions of multiple dependencies to address vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/miduga/s3-folder-upload/#readme",
   "dependencies": {
-    "async": "3.2.0",
+    "async": "3.2.6",
     "aws-sdk": "2.647.0",
     "globby": "10.0.1",
     "log-update": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/miduga/s3-folder-upload/#readme",
   "dependencies": {
     "async": "3.2.6",
-    "aws-sdk": "2.647.0",
+    "aws-sdk": "2.1692.0",
     "globby": "10.0.1",
     "log-update": "3.3.0",
     "minimist": "1.2.8"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "aws-sdk": "2.647.0",
     "globby": "10.0.1",
     "log-update": "3.3.0",
-    "minimist": "1.2.5"
+    "minimist": "1.2.8"
   },
   "devDependencies": {
     "np": "6.2.0",


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| Component | CVE ID  | Severity | Description       |
|-------|-------|-----|-----------|
| npm:minimist:1.2.0 | CVE-2021-44906 | Critical | Minimist <=1.2.5 is vulnerable to Prototype Pollution via file index.js, function setKey() (lines 69-95). |
| npm:async:3.2.0 | CVE-2021-43138 | High | In Async before 2.6.4 and 3.x before 3.2.2, a malicious user can obtain privileges via the mapValues() method, aka lib/internal/iterator.js createObjectIterator prototype pollution.|
| npm:aws-sdk:2.647.0 | CVE-2020-28472 | Critical | This affects the package @aws-sdk/shared-ini-file-loader before 1.0.0-rc.9; the package aws-sdk before 2.814.0. If an attacker submits a malicious INI file to an application that parses it with loadSharedConfigFiles , they will pollute the prototype on the application. This can be exploited further depending on the context. |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
